### PR TITLE
비밀번호 암호화 구현 및 security config 수정

### DIFF
--- a/src/main/java/com/woorifisa/backend/common/entity/Member.java
+++ b/src/main/java/com/woorifisa/backend/common/entity/Member.java
@@ -2,6 +2,8 @@ package com.woorifisa.backend.common.entity;
 
 import java.time.LocalDate;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
@@ -38,4 +40,11 @@ public class Member {
     private String memAddr;
     @NotNull
     private int memType;
+
+
+
+    // 입력된 평문형식의 pw와 db에 저장된 암호화된 pw 비교
+    public boolean checkPassword(String plainPassword, PasswordEncoder passwordEncoder) {
+    return passwordEncoder.matches(plainPassword, this.memPw);
+  }
 }

--- a/src/main/java/com/woorifisa/backend/common/security/springsecurity/SecurityConfig.java
+++ b/src/main/java/com/woorifisa/backend/common/security/springsecurity/SecurityConfig.java
@@ -1,39 +1,45 @@
 package com.woorifisa.backend.common.security.springsecurity;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.encrypt.AesBytesEncryptor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 // @Configuration annotation이 @EnableWebSecurity에 포함되어 있음
+@Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     // 대칭키
+    /* 
     @Value("${symmetric.key}")
     private String symmetrickey;
+    */
 
     // PasswordEncoder interface의 구현체가 BCryptPasswordEncoder임을 수동 빈 등록을 통해 명시
+    // 이를 통해 의존성을 주입 받아 사용 가능
     @Bean
-    public PasswordEncoder passwordEncoder() {
+    PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
+    /* 
     // AesBytesEncryptor 사용을 위한 Bean등록
     @Bean
-    public AesBytesEncryptor aesBytesEncryptor() {
+    AesBytesEncryptor aesBytesEncryptor() {
         return new AesBytesEncryptor(symmetrickey,"70726574657374");
     }
-
+        */
+   
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable();
+                .csrf(csrf -> csrf.disable());
+                
         // CSRF(크로스 사이트 요청 위조)라는 인증된 사용자를 이용해
         // 서버에 위험을 끼치는 요청들을 보내는 공격을 방어하기 위해 post 요청마다 token이 필요한 과정을 생략하겠음을 의미
         return http.build();
     }
+      
 }

--- a/src/main/java/com/woorifisa/backend/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/woorifisa/backend/member/service/AuthServiceImpl.java
@@ -2,6 +2,7 @@ package com.woorifisa.backend.member.service;
 
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,6 +25,9 @@ public class AuthServiceImpl implements AuthService {
     @Autowired
     MemberRepository memberRepository;
 
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
     private ModelMapper mapper = new ModelMapper(); 
 
     @Override
@@ -31,7 +35,7 @@ public class AuthServiceImpl implements AuthService {
         Member member = memberRepository.findByMemId(id);
         System.out.println(member);
         if (member != null) {
-            if (pw.equals(member.getMemPw())) {
+            if (member.checkPassword(pw, passwordEncoder)) {
                 LoginSessionDTO login = mapper.map(member, LoginSessionDTO.class);
                 System.out.println(login);
                 HttpSession session = request.getSession();
@@ -64,7 +68,7 @@ public class AuthServiceImpl implements AuthService {
         }
 
         try{
-            memberRepository.insertMem(memberInfoDTO.getMemName(), memberInfoDTO.getMemId(), memberInfoDTO.getMemPw(), 
+            memberRepository.insertMem(memberInfoDTO.getMemName(), memberInfoDTO.getMemId(), passwordEncoder.encode(memberInfoDTO.getMemPw()), 
                                        memberInfoDTO.getMemEmail(), memberInfoDTO.getMemPhone(), memberInfoDTO.getMemSex(), 
                                        memberInfoDTO.getMemAddr(), memberInfoDTO.getMemBirth(), memberInfoDTO.getMemType());
         } catch (Exception e) {


### PR DESCRIPTION
#44

- Bcrypt 알고리즘을 활용하여 회원가입 시, 회원의 비밀번호를 암호화 하여 저장
- 로그인 시 유저가 입력한 비밀번호를 암호화된 비밀번호를 통해 검증
- security config @Configuration 어노테이션이 없어 빈 객체를 탐지하지 못하던 error 수정
- filterchain 람다 형식으로 변경
- 일부 알고리즘 선언 코드 주석 처리