### PR TITLE
feat : #52 관련 회원정보 수정시 password검증,  exception handler 추가

### DIFF
--- a/src/main/java/com/woorifisa/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/woorifisa/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.woorifisa.backend.common.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import com.woorifisa.backend.member.exception.JoinException;
+import com.woorifisa.backend.member.exception.NotValidPasswordException;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(NotValidPasswordException.class)
+    public ResponseEntity<Map<String, String>> handleNotValidPasswordException(NotValidPasswordException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", ex.getMessage()); // 예외 메시지
+        return ResponseEntity.badRequest().body(response); // 400 상태 코드
+    }
+
+    @ExceptionHandler(SessionNotValidException.class)
+    public ResponseEntity<Map<String, String>> SessionNotValidException(SessionNotValidException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", ex.getMessage()); // 예외 메시지
+        return ResponseEntity.badRequest().body(response); // 400 상태 코드
+    }
+
+    @ExceptionHandler(JoinException.class)
+    public ResponseEntity<Map<String, String>> JoinException(JoinException ex) {
+        Map<String, String> response = new HashMap<>();
+        response.put("message", ex.getMessage()); // 예외 메시지
+        return ResponseEntity.badRequest().body(response); // 400 상태 코드
+    }
+}

--- a/src/main/java/com/woorifisa/backend/common/repository/MemberRepository.java
+++ b/src/main/java/com/woorifisa/backend/common/repository/MemberRepository.java
@@ -14,6 +14,7 @@ import com.woorifisa.backend.common.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
     Member findByMemId(String memId);
+    Member findByMemNum(String memNum);
 
     @Query(value = "select * from member order by mem_num", nativeQuery = true)
     public List<Member> memberAll();

--- a/src/main/java/com/woorifisa/backend/common/security/springsecurity/SecurityConfig.java
+++ b/src/main/java/com/woorifisa/backend/common/security/springsecurity/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
         {  
             "/auth/sessionInfo",
             "/member/**",
+            "/subscription/**",
             "/main/subscriptionInsert",
             "/main/reviewInsert/reviewInsert",
             "/main/reviewDelete",

--- a/src/main/java/com/woorifisa/backend/member/controller/AuthController.java
+++ b/src/main/java/com/woorifisa/backend/member/controller/AuthController.java
@@ -5,10 +5,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.woorifisa.backend.member.dto.MemberInfoDTO;
+import com.woorifisa.backend.member.dto.JoinDTO;
 import com.woorifisa.backend.member.exception.JoinException;
 import com.woorifisa.backend.member.service.AuthService;
-
 import io.swagger.v3.oas.annotations.Operation;
 
 @RequestMapping("/auth")
@@ -21,8 +20,8 @@ public class AuthController {
 
     @PostMapping("/join")
     @Operation(summary = "회원가입 (개발 완료)", description = "회원가입 시 회원 정보를 저장")
-    public String join(@RequestBody MemberInfoDTO memberInfoDTO) throws JoinException{
-        return authService.join(memberInfoDTO);
+    public String join(@RequestBody JoinDTO joinDTO) throws JoinException{
+        return authService.join(joinDTO);
     }
     // 세션 정보 조회 로직 수정해야함
     /*

--- a/src/main/java/com/woorifisa/backend/member/controller/MemberInfoController.java
+++ b/src/main/java/com/woorifisa/backend/member/controller/MemberInfoController.java
@@ -11,11 +11,12 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.woorifisa.backend.common.exception.SessionNotValidException;
 import com.woorifisa.backend.common.security.springsecurity.MemberDetail;
 import com.woorifisa.backend.member.dto.MemberInfoDTO;
+import com.woorifisa.backend.member.dto.MemberInfoEditDTO;
 import com.woorifisa.backend.member.dto.SubscriptionResponseDTO;
+import com.woorifisa.backend.member.exception.NotValidPasswordException;
 import com.woorifisa.backend.member.service.AuthService;
 import com.woorifisa.backend.member.service.MemberInfoService;
 
@@ -40,8 +41,8 @@ public class MemberInfoController {
 
     @PutMapping("/info/update")
     @Operation(summary = "유저 정보 수정 (개발 완료 - 그러나 예외 처리 추가 해야함)", description = "user 로그인 정보 검증 후 정보 수정")
-    public String updateMemberInfo(@RequestBody MemberInfoDTO memberInfoDTO, @AuthenticationPrincipal MemberDetail memberDetail) throws SessionNotValidException {
-        return memberInfoService.updateMemberInfo(memberInfoDTO, memberDetail.getMemNum()); 
+    public String updateMemberInfo(@RequestBody MemberInfoEditDTO memberInfoEditDTO, @AuthenticationPrincipal MemberDetail memberDetail) throws NotValidPasswordException, SessionNotValidException {
+        return memberInfoService.updateMemberInfo(memberInfoEditDTO, memberDetail.getMemNum()); 
     }
     
     @GetMapping("/sublist/get")

--- a/src/main/java/com/woorifisa/backend/member/dto/JoinDTO.java
+++ b/src/main/java/com/woorifisa/backend/member/dto/JoinDTO.java
@@ -1,0 +1,26 @@
+package com.woorifisa.backend.member.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Setter
+@Getter
+@ToString
+@Builder
+public class JoinDTO {
+    private String memId;
+    private String memPw;
+    private String memName;
+    private String memEmail;
+    private String memPhone;
+    private String memSex;
+    private LocalDate memBirth;
+    private String memAddr;
+    private int memType;
+}

--- a/src/main/java/com/woorifisa/backend/member/dto/MemberInfoDTO.java
+++ b/src/main/java/com/woorifisa/backend/member/dto/MemberInfoDTO.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 @Builder
 public class MemberInfoDTO {
     private String memId;
-    private String memPw;
     private String memName;
     private String memEmail;
     private String memPhone;

--- a/src/main/java/com/woorifisa/backend/member/dto/MemberInfoEditDTO.java
+++ b/src/main/java/com/woorifisa/backend/member/dto/MemberInfoEditDTO.java
@@ -1,0 +1,26 @@
+package com.woorifisa.backend.member.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Setter
+@Getter
+@ToString
+@Builder
+public class MemberInfoEditDTO {
+    private String memId;
+    private String memPw;
+    private String memName;
+    private String memEmail;
+    private String memPhone;
+    private String memSex;
+    private LocalDate memBirth;
+    private String memAddr;
+    private int memType;
+}

--- a/src/main/java/com/woorifisa/backend/member/exception/NotValidPasswordException.java
+++ b/src/main/java/com/woorifisa/backend/member/exception/NotValidPasswordException.java
@@ -1,0 +1,8 @@
+package com.woorifisa.backend.member.exception;
+
+public class NotValidPasswordException extends Exception{
+    public NotValidPasswordException() {}
+	public NotValidPasswordException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/woorifisa/backend/member/service/AuthService.java
+++ b/src/main/java/com/woorifisa/backend/member/service/AuthService.java
@@ -1,9 +1,9 @@
 package com.woorifisa.backend.member.service;
 
-import com.woorifisa.backend.member.dto.MemberInfoDTO;
+import com.woorifisa.backend.member.dto.JoinDTO;
 import com.woorifisa.backend.member.exception.JoinException;
 
 public interface AuthService {
 
-    public String join(MemberInfoDTO memberInfoDTO) throws JoinException;
+    public String join(JoinDTO joinDTO) throws JoinException;
 }

--- a/src/main/java/com/woorifisa/backend/member/service/AuthServiceImpl.java
+++ b/src/main/java/com/woorifisa/backend/member/service/AuthServiceImpl.java
@@ -4,10 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.woorifisa.backend.common.entity.Member;
 import com.woorifisa.backend.common.repository.MemberRepository;
-import com.woorifisa.backend.member.dto.MemberInfoDTO;
+import com.woorifisa.backend.member.dto.JoinDTO;
 import com.woorifisa.backend.member.exception.JoinException;
 
 @Service
@@ -22,17 +21,20 @@ public class AuthServiceImpl implements AuthService {
 
     @Transactional
     @Override
-    public String join(MemberInfoDTO memberInfoDTO) throws JoinException {
-        String newMemID = memberInfoDTO.getMemId();
+    public String join(JoinDTO joinDTO) throws JoinException {
+        String newMemID = joinDTO.getMemId();
         Member findedMember = memberRepository.findByMemId(newMemID);
         if (findedMember != null){
-            throw new JoinException("이미 존재하는 ID");
+            throw new JoinException("이미 존재하는 ID입니다.");
+        }
+        if (joinDTO.getMemPw().length() < 4){
+            throw new JoinException("4자 이상의 비밀번호를 입력해 주세요.");
         }
 
         try{
-            memberRepository.insertMem(memberInfoDTO.getMemName(), memberInfoDTO.getMemId(), passwordEncoder.encode(memberInfoDTO.getMemPw()), 
-                                       memberInfoDTO.getMemEmail(), memberInfoDTO.getMemPhone(), memberInfoDTO.getMemSex(), 
-                                       memberInfoDTO.getMemAddr(), memberInfoDTO.getMemBirth(), memberInfoDTO.getMemType());
+            memberRepository.insertMem(joinDTO.getMemName(), joinDTO.getMemId(), passwordEncoder.encode(joinDTO.getMemPw()), 
+                                       joinDTO.getMemEmail(), joinDTO.getMemPhone(), joinDTO.getMemSex(), 
+                                       joinDTO.getMemAddr(), joinDTO.getMemBirth(), joinDTO.getMemType());
         } catch (Exception e) {
             e.printStackTrace();
             throw new JoinException("회원가입 실패");

--- a/src/main/java/com/woorifisa/backend/member/service/MemberInfoService.java
+++ b/src/main/java/com/woorifisa/backend/member/service/MemberInfoService.java
@@ -2,13 +2,16 @@ package com.woorifisa.backend.member.service;
 
 import java.util.List;
 
+import com.woorifisa.backend.common.exception.SessionNotValidException;
 import com.woorifisa.backend.member.dto.MemberInfoDTO;
+import com.woorifisa.backend.member.dto.MemberInfoEditDTO;
 import com.woorifisa.backend.member.dto.SubscriptionResponseDTO;
+import com.woorifisa.backend.member.exception.NotValidPasswordException;
 
 
 public interface MemberInfoService {
     public MemberInfoDTO getMemberInfo(String memId);
-    public String updateMemberInfo(MemberInfoDTO memberInfoDTO, String memNum);
+    public String updateMemberInfo(MemberInfoEditDTO memberInfoEditDTO, String memNum) throws NotValidPasswordException, SessionNotValidException;
     public List<SubscriptionResponseDTO> getSubList(String memNum) throws Exception;
     public String deleteSub(String subNum) throws Exception;
 } 


### PR DESCRIPTION
#52

- 충돌 해결 및 회원 정보 수정시 password 검증하도록 memberInfoService의 코드 수정
- memberInfoDTO의 password를 제외했으므로 회원가입에 비밀번호가 필요한 joinDTO와 정보 수정 시 비밀번호를 검증해야 하는 
  MemberInfoEditDTO 추가
- exception handler 추가
